### PR TITLE
drivers: clk: renesas: computing clock base on bpp and lanes

### DIFF
--- a/drivers/gpu/drm/renesas/rcar-du/rzg2l_mipi_dsi.c
+++ b/drivers/gpu/drm/renesas/rcar-du/rzg2l_mipi_dsi.c
@@ -25,6 +25,7 @@
 #include <drm/drm_probe_helper.h>
 
 #include "rzg2l_mipi_dsi_regs.h"
+#include "rzg2l_mipi_dsi.h"
 
 struct rzg2l_mipi_dsi {
 	struct device *dev;
@@ -285,8 +286,6 @@ static int rzg2l_mipi_dsi_startup(struct rzg2l_mipi_dsi *dsi,
 	ret = pm_runtime_resume_and_get(dsi->dev);
 	if (ret < 0)
 		return ret;
-
-	clk_set_rate(dsi->vclk, mode->clock * 1000);
 
 	ret = rzg2l_mipi_dsi_dphy_init(dsi, hsfreq);
 	if (ret < 0)
@@ -601,6 +600,22 @@ static const struct drm_bridge_funcs rzg2l_mipi_dsi_bridge_ops = {
 /* -----------------------------------------------------------------------------
  * Host setting
  */
+
+int rzg2l_mipi_dsi_get_data_lanes(struct platform_device *pdev)
+{
+	struct rzg2l_mipi_dsi *dsi = platform_get_drvdata(pdev);
+
+	return dsi->lanes;
+}
+EXPORT_SYMBOL_GPL(rzg2l_mipi_dsi_get_data_lanes);
+
+int rzg2l_mipi_dsi_get_bpp(struct platform_device *pdev)
+{
+	struct rzg2l_mipi_dsi *dsi = platform_get_drvdata(pdev);
+
+	return mipi_dsi_pixel_format_to_bpp(dsi->format);
+}
+EXPORT_SYMBOL_GPL(rzg2l_mipi_dsi_get_bpp);
 
 static int rzg2l_mipi_dsi_host_attach(struct mipi_dsi_host *host,
 				      struct mipi_dsi_device *device)

--- a/drivers/gpu/drm/renesas/rcar-du/rzg2l_mipi_dsi.h
+++ b/drivers/gpu/drm/renesas/rcar-du/rzg2l_mipi_dsi.h
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * RZ/G2L MIPI DSI Encoder Header
+ *
+ * Copyright (C) 2021 Renesas Electronics Corporation
+ */
+
+#ifndef __RZG2L_MIPI_DSI_H__
+#define __RZG2L_MIPI_DSI_H__
+
+struct platform_device;
+
+#if IS_ENABLED(CONFIG_DRM_RZG2L_MIPI_DSI)
+int rzg2l_mipi_dsi_get_data_lanes(struct platform_device *pdev);
+int rzg2l_mipi_dsi_get_bpp(struct platform_device *pdev);
+#else
+static inline int rzg2l_mipi_dsi_get_data_lanes(struct platform_device *pdev)
+{
+	return 0;
+}
+static inline int rzg2l_mipi_dsi_get_bpp(struct platform_device *pdev)
+{
+	return 0;
+}
+#endif /* CONFIG_DRM_RZG2L_MIPI_DSI */
+#endif /* __RZG2L_MIPI_DSI_H__ */

--- a/drivers/gpu/drm/renesas/rz-du/Makefile
+++ b/drivers/gpu/drm/renesas/rz-du/Makefile
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0
+
+CFLAGS_rzg2l_du_crtc.o := -I$(srctree)/drivers/gpu/drm/renesas/rcar-du
+
 rzg2l-du-drm-y := rzg2l_du_crtc.o \
 		  rzg2l_du_drv.o \
 		  rzg2l_du_encoder.o \

--- a/drivers/gpu/drm/renesas/rz-du/rzg2l_du_crtc.h
+++ b/drivers/gpu/drm/renesas/rz-du/rzg2l_du_crtc.h
@@ -62,6 +62,24 @@ struct rzg2l_du_crtc {
 	} rzg2l_clocks;
 };
 
+struct cpg_param {
+	u32	frequency;
+	u32	pl5_refdiv;
+	u32	pl5_intin;
+	u32	pl5_fracin;
+	u32	pl5_postdiv1;
+	u32	pl5_postdiv2;
+	u32	pl5_divval;
+	u32	pl5_spread;
+	u32	dsi_div_a;
+	u32	dsi_div_b;
+	u32	sel_pll5_4;
+};
+
+#define OSCLK_HZ 24000000
+#define reg_write(x, a)		iowrite32(a, x)
+#define CPG_LPCLK_DIV		0
+
 static inline struct rzg2l_du_crtc *to_rzg2l_crtc(struct drm_crtc *c)
 {
 	return container_of(c, struct rzg2l_du_crtc, crtc);


### PR DESCRIPTION
This PR is for an internal review of the clock calculation formula and clock flexibility based on the BPP and data lines